### PR TITLE
Define all protocol messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,18 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.9",
+ "syn 1.0.60",
+]
+
+[[package]]
+name = "enum-display-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f76eb63c4bfc6fce5000f106254701b741fc9a65ee08445fde0ff39e583f1c"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
 ]
 
 [[package]]
@@ -121,8 +131,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.9",
+ "syn 1.0.60",
  "version_check",
 ]
 
@@ -133,7 +143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.9",
  "version_check",
 ]
 
@@ -143,8 +153,14 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.1",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -161,7 +177,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "enum-display-derive",
  "serde",
+ "thiserror",
  "toml",
 ]
 
@@ -181,8 +199,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -193,13 +211,33 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
- "quote",
- "unicode-xid",
+ "quote 1.0.9",
+ "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -218,6 +256,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -240,6 +298,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ clap = "3.0.0-beta.2"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 anyhow = "1.0"
+thiserror = "1.0"
+enum-display-derive = "0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::{crate_version, Clap};
 
 pub mod config;
+pub mod protocol;
 
 #[derive(Clap)]
 #[clap(version = crate_version!())]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
 use clap::{crate_version, Clap};
+#[macro_use]
+extern crate enum_display_derive;
 
 pub mod config;
 pub mod protocol;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -19,3 +19,9 @@ pub struct PiecePayload {
     begin: usize,
     piece: Vec<u8>,
 }
+
+pub struct CancelPayload {
+    index: usize,
+    begin: usize,
+    length: usize,
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -25,3 +25,15 @@ pub struct CancelPayload {
     begin: usize,
     length: usize,
 }
+
+enum PeerMessage {
+    Choke,
+    Unchoke,
+    Interested,
+    NotInterested,
+    Have(HavePayload),
+    Bitfield(BitfieldPayload),
+    Request(RequestPayload),
+    Piece(PiecePayload),
+    Cancel(CancelPayload),
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -680,4 +680,100 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_have_normal() {
+        let bytes: Bytes =
+            vec![0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x00, 0x00, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        dbg!(&result);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage =
+            PeerMessage::Have(HavePayload { index: 255 });
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_have_abnormal_bad_id() {
+        let bytes: Bytes =
+            vec![0x00, 0x00, 0x00, 0x05, 0xff, 0x00, 0x00, 0x00, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_have_abnormal_bad_length() {
+        let bytes: Bytes =
+            vec![0x00, 0x00, 0x00, 0xff, 0x04, 0x00, 0x00, 0x00, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_have_abnormal_surplus_data() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x08, 0x04, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00,
+            0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooLong;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_have_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_have_normal() {
+        let message: PeerMessage =
+            PeerMessage::Have(HavePayload { index: 255 });
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes =
+            vec![0x00, 0x00, 0x00, 0x05, 0x04, 0x00, 0x00, 0x00, 0xff];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -75,16 +75,63 @@ impl TryFrom<Bytes> for RequestPayload {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PiecePayload {
-    index: usize,
-    begin: usize,
+    index: u32,
+    begin: u32,
     piece: Vec<u8>,
+}
+
+impl TryFrom<Bytes> for PiecePayload {
+    type Error = DecodeError;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        if value.len() > 3 * size_of::<u32>() {
+            return Err(Self::Error::TooLong);
+        }
+
+        if value.len() < 3 * size_of::<u32>() {
+            return Err(Self::Error::TooShort);
+        }
+
+        let index_bytes: [u8; 4] = [value[0], value[1], value[2], value[3]];
+        let begin_bytes: [u8; 4] = [value[4], value[5], value[6], value[7]];
+
+        Ok(Self {
+            index: u32::from_be_bytes(index_bytes),
+            begin: u32::from_be_bytes(begin_bytes),
+            piece: value[8..].to_vec(),
+        })
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CancelPayload {
-    index: usize,
-    begin: usize,
-    length: usize,
+    index: u32,
+    begin: u32,
+    length: u32,
+}
+
+impl TryFrom<Bytes> for CancelPayload {
+    type Error = DecodeError;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        if value.len() > 3 * size_of::<u32>() {
+            return Err(Self::Error::TooLong);
+        }
+
+        if value.len() < 3 * size_of::<u32>() {
+            return Err(Self::Error::TooShort);
+        }
+
+        let index_bytes: [u8; 4] = [value[0], value[1], value[2], value[3]];
+        let begin_bytes: [u8; 4] = [value[4], value[5], value[6], value[7]];
+        let length_bytes: [u8; 4] = [value[8], value[9], value[10], value[11]];
+
+        Ok(Self {
+            index: u32::from_be_bytes(index_bytes),
+            begin: u32::from_be_bytes(begin_bytes),
+            length: u32::from_be_bytes(length_bytes),
+        })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -504,4 +504,92 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_interested_normal() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x02];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage = PeerMessage::Interested;
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_interested_abnormal_bad_id() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_interested_abnormal_bad_length() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0xff, 0x02];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_interested_abnormal_surplus_data() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x08, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooLong;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_interested_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_interested_normal() {
+        let message: PeerMessage = PeerMessage::Interested;
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x02];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -234,10 +234,10 @@ impl TryFrom<Bytes> for PeerMessage {
             3 => Ok(Self::NotInterested),
             4 => Ok(Self::Have(HavePayload::try_from(value[5..].to_vec())?)),
             5 => Ok(Self::Bitfield(BitfieldPayload::try_from(
-                value[8..].to_vec(),
+                value[5..].to_vec(),
             )?)),
             6 => Ok(Self::Request(RequestPayload::try_from(
-                value[8..].to_vec(),
+                value[5..].to_vec(),
             )?)),
             7 => Ok(Self::Piece(PiecePayload::try_from(value[5..].to_vec())?)),
             8 => {
@@ -688,8 +688,6 @@ mod tests {
 
         let result: Result<PeerMessage, DecodeError> =
             PeerMessage::try_from(bytes);
-
-        dbg!(&result);
 
         assert!(result.is_ok());
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -304,7 +304,7 @@ impl From<PeerMessage> for Bytes {
                 };
             }
             PeerMessage::Cancel(p) => {
-                length = 12;
+                length = 13;
                 id = 8;
                 payload = {
                     let tmp: Vec<Bytes> = vec![
@@ -1038,4 +1038,5 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -857,4 +857,95 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_request_normal() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0x06, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage =
+            PeerMessage::Request(RequestPayload {
+                index: 33,
+                begin: 2048,
+                length: 256,
+            });
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_request_abnormal_bad_id() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0xff, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_request_abnormal_bad_length() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_request_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_request_normal() {
+        let message: PeerMessage = PeerMessage::Request(RequestPayload {
+            index: 33,
+            begin: 2048,
+            length: 256,
+        });
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0x06, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,3 +3,7 @@
 pub struct HavePayload {
     index: usize,
 }
+
+pub struct BitfieldPayload {
+    bitfield: Vec<u8>,
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -58,6 +58,12 @@ impl TryFrom<Bytes> for BitfieldPayload {
     }
 }
 
+impl From<BitfieldPayload> for Bytes {
+    fn from(value: BitfieldPayload) -> Self {
+        value.bitfield
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RequestPayload {
     index: u32,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1039,4 +1039,94 @@ mod tests {
         assert_eq!(actual_bytes, expected_bytes);
     }
 
+    #[test]
+    fn test_decode_cancel_normal() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0x08, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage =
+            PeerMessage::Cancel(CancelPayload {
+                index: 33,
+                begin: 2048,
+                length: 256,
+            });
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_cancel_abnormal_bad_id() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0xff, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_cancel_abnormal_bad_length() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_cancel_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_cancel_normal() {
+        let message: PeerMessage = PeerMessage::Cancel(CancelPayload {
+            index: 33,
+            begin: 2048,
+            length: 256,
+        });
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0x08, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -774,4 +774,87 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_bitfield_normal() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x09, 0x05, 0xca, 0xfe, 0xbe, 0xef, 0xff, 0xff,
+            0xff, 0xf0,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage =
+            PeerMessage::Bitfield(BitfieldPayload {
+                bitfield: vec![0xca, 0xfe, 0xbe, 0xef, 0xff, 0xff, 0xff, 0xf0],
+            });
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_bitfield_abnormal_bad_id() {
+        let bytes: Bytes =
+            vec![0x00, 0x00, 0x00, 0x05, 0xff, 0x00, 0x00, 0x00, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_bitfield_abnormal_bad_length() {
+        let bytes: Bytes =
+            vec![0x00, 0x00, 0x00, 0xff, 0x05, 0x00, 0x00, 0x00, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_bitfield_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_bitfield_normal() {
+        let message: PeerMessage = PeerMessage::Bitfield(BitfieldPayload {
+            bitfield: vec![0xca, 0xfe, 0xbe, 0xef, 0xff, 0xff, 0xff, 0xf0],
+        });
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x09, 0x05, 0xca, 0xfe, 0xbe, 0xef, 0xff, 0xff,
+            0xff, 0xf0,
+        ];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -137,6 +137,18 @@ impl TryFrom<Bytes> for PiecePayload {
     }
 }
 
+impl From<PiecePayload> for Bytes {
+    fn from(value: PiecePayload) -> Self {
+        let mut bytes: Bytes = vec![];
+
+        bytes.extend_from_slice(&value.index.to_be_bytes());
+        bytes.extend_from_slice(&value.begin.to_be_bytes());
+        bytes.extend_from_slice(&value.piece);
+
+        bytes
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CancelPayload {
     index: u32,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -39,6 +39,12 @@ impl TryFrom<Bytes> for HavePayload {
     }
 }
 
+impl From<HavePayload> for Bytes {
+    fn from(value: HavePayload) -> Self {
+        value.index.to_be_bytes().to_vec()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BitfieldPayload {
     bitfield: Vec<u8>,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,13 @@
 #![allow(dead_code)]
+use std::fmt::Display;
+
+use thiserror::Error;
+
+#[derive(Debug, Display, PartialEq, Eq, Error)]
+pub enum DecodeError {
+    TooLong,
+    TooShort,
+}
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HavePayload {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,11 @@
 #![allow(dead_code)]
+use std::convert::TryFrom;
 use std::fmt::Display;
+use std::mem::size_of;
 
 use thiserror::Error;
+
+type Bytes = Vec<u8>;
 
 #[derive(Debug, Display, PartialEq, Eq, Error)]
 pub enum DecodeError {
@@ -11,7 +15,26 @@ pub enum DecodeError {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HavePayload {
-    index: usize,
+    index: u32,
+}
+
+impl TryFrom<Bytes> for HavePayload {
+    type Error = DecodeError;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        if value.len() > size_of::<u32>() {
+            return Err(Self::Error::TooLong);
+        }
+
+        if value.len() < size_of::<u32>() {
+            return Err(Self::Error::TooShort);
+        }
+
+        let bytes_array: [u8; 4] = [value[0], value[1], value[2], value[3]];
+        Ok(Self {
+            index: u32::from_be_bytes(bytes_array),
+        })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -252,7 +252,7 @@ impl From<PeerMessage> for Bytes {
     fn from(value: PeerMessage) -> Self {
         /* fields we'll be mutating along the way */
         let mut length: u32 = 1;
-        let id: u32;
+        let id: u8;
         let mut payload: Bytes = vec![];
 
         /* handle each message case */
@@ -319,9 +319,101 @@ impl From<PeerMessage> for Bytes {
 
         /* marshal everything into bytes */
         let length_bytes: Bytes = length.to_be_bytes().to_vec();
-        let id_bytes: Bytes = id.to_be_bytes().to_vec();
-        let bytes: Vec<Bytes> = vec![length_bytes, id_bytes, payload];
+        let bytes: Vec<Bytes> = vec![length_bytes, vec![id], payload];
 
         bytes.iter().flatten().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_choke_normal() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage = PeerMessage::Choke;
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_choke_abnormal_bad_id() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_choke_abnormal_bad_length() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0xff, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_choke_abnormal_surplus_data() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooLong;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_choke_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_choke_normal() {
+        let message: PeerMessage = PeerMessage::Choke;
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x00];
+
+        assert_eq!(actual_bytes, expected_bytes);
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -42,6 +42,14 @@ pub struct BitfieldPayload {
     bitfield: Vec<u8>,
 }
 
+impl TryFrom<Bytes> for BitfieldPayload {
+    type Error = DecodeError;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        Ok(Self { bitfield: value })
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RequestPayload {
     index: u32,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -948,4 +948,94 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_piece_normal() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0x07, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage = PeerMessage::Piece(PiecePayload {
+            index: 33,
+            begin: 2048,
+            piece: vec![0x00, 0x00, 0x01, 0x00],
+        });
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_piece_abnormal_bad_id() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0xff, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_piece_abnormal_bad_length() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_piece_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_piece_normal() {
+        let message: PeerMessage = PeerMessage::Piece(PiecePayload {
+            index: 33,
+            begin: 2048,
+            piece: vec![0x00, 0x00, 0x01, 0x00],
+        });
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x0d, 0x07, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00, 0x01, 0x00,
+        ];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -176,19 +176,19 @@ impl TryFrom<Bytes> for PeerMessage {
         let id: u32 = u32::from_be_bytes(id_bytes);
 
         match id {
-            1 => Ok(Self::Choke),
-            2 => Ok(Self::Unchoke),
-            3 => Ok(Self::Interested),
-            4 => Ok(Self::NotInterested),
-            5 => Ok(Self::Have(HavePayload::try_from(value[8..].to_vec())?)),
-            6 => Ok(Self::Bitfield(BitfieldPayload::try_from(
+            0 => Ok(Self::Choke),
+            1 => Ok(Self::Unchoke),
+            2 => Ok(Self::Interested),
+            3 => Ok(Self::NotInterested),
+            4 => Ok(Self::Have(HavePayload::try_from(value[8..].to_vec())?)),
+            5 => Ok(Self::Bitfield(BitfieldPayload::try_from(
                 value[8..].to_vec(),
             )?)),
-            7 => Ok(Self::Request(RequestPayload::try_from(
+            6 => Ok(Self::Request(RequestPayload::try_from(
                 value[8..].to_vec(),
             )?)),
-            8 => Ok(Self::Piece(PiecePayload::try_from(value[8..].to_vec())?)),
-            9 => {
+            7 => Ok(Self::Piece(PiecePayload::try_from(value[8..].to_vec())?)),
+            8 => {
                 Ok(Self::Cancel(CancelPayload::try_from(value[8..].to_vec())?))
             }
             _ => Err(DecodeError::InvalidMessageType),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -280,7 +280,7 @@ impl From<PeerMessage> for Bytes {
                 payload = p.into();
             }
             PeerMessage::Request(p) => {
-                length = 12;
+                length = 13;
                 id = 6;
                 payload = {
                     let tmp: Vec<Bytes> = vec![

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -44,9 +44,33 @@ pub struct BitfieldPayload {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RequestPayload {
-    index: usize,
-    begin: usize,
-    length: usize,
+    index: u32,
+    begin: u32,
+    length: u32,
+}
+
+impl TryFrom<Bytes> for RequestPayload {
+    type Error = DecodeError;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        if value.len() > 3 * size_of::<u32>() {
+            return Err(Self::Error::TooLong);
+        }
+
+        if value.len() < 3 * size_of::<u32>() {
+            return Err(Self::Error::TooShort);
+        }
+
+        let index_bytes: [u8; 4] = [value[0], value[1], value[2], value[3]];
+        let begin_bytes: [u8; 4] = [value[4], value[5], value[6], value[7]];
+        let length_bytes: [u8; 4] = [value[8], value[9], value[10], value[11]];
+
+        Ok(Self {
+            index: u32::from_be_bytes(index_bytes),
+            begin: u32::from_be_bytes(begin_bytes),
+            length: u32::from_be_bytes(length_bytes),
+        })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -7,3 +7,9 @@ pub struct HavePayload {
 pub struct BitfieldPayload {
     bitfield: Vec<u8>,
 }
+
+pub struct RequestPayload {
+    index: usize,
+    begin: usize,
+    length: usize,
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -180,6 +180,18 @@ impl TryFrom<Bytes> for CancelPayload {
     }
 }
 
+impl From<CancelPayload> for Bytes {
+    fn from(value: CancelPayload) -> Self {
+        let mut bytes: Bytes = vec![];
+
+        bytes.extend_from_slice(&value.index.to_be_bytes());
+        bytes.extend_from_slice(&value.begin.to_be_bytes());
+        bytes.extend_from_slice(&value.length.to_be_bytes());
+
+        bytes
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum PeerMessage {
     Choke,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,31 +1,37 @@
 #![allow(dead_code)]
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HavePayload {
     index: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BitfieldPayload {
     bitfield: Vec<u8>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RequestPayload {
     index: usize,
     begin: usize,
     length: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PiecePayload {
     index: usize,
     begin: usize,
     piece: Vec<u8>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct CancelPayload {
     index: usize,
     begin: usize,
     length: usize,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum PeerMessage {
     Choke,
     Unchoke,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,5 @@
+#![allow(dead_code)]
+
+pub struct HavePayload {
+    index: usize,
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -71,6 +71,18 @@ pub struct RequestPayload {
     length: u32,
 }
 
+impl From<RequestPayload> for Bytes {
+    fn from(value: RequestPayload) -> Self {
+        let mut bytes: Bytes = vec![];
+
+        bytes.extend_from_slice(&value.index.to_be_bytes());
+        bytes.extend_from_slice(&value.begin.to_be_bytes());
+        bytes.extend_from_slice(&value.length.to_be_bytes());
+
+        bytes
+    }
+}
+
 impl TryFrom<Bytes> for RequestPayload {
     type Error = DecodeError;
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -232,16 +232,16 @@ impl TryFrom<Bytes> for PeerMessage {
             1 => Ok(Self::Unchoke),
             2 => Ok(Self::Interested),
             3 => Ok(Self::NotInterested),
-            4 => Ok(Self::Have(HavePayload::try_from(value[8..].to_vec())?)),
+            4 => Ok(Self::Have(HavePayload::try_from(value[5..].to_vec())?)),
             5 => Ok(Self::Bitfield(BitfieldPayload::try_from(
                 value[8..].to_vec(),
             )?)),
             6 => Ok(Self::Request(RequestPayload::try_from(
                 value[8..].to_vec(),
             )?)),
-            7 => Ok(Self::Piece(PiecePayload::try_from(value[8..].to_vec())?)),
+            7 => Ok(Self::Piece(PiecePayload::try_from(value[5..].to_vec())?)),
             8 => {
-                Ok(Self::Cancel(CancelPayload::try_from(value[8..].to_vec())?))
+                Ok(Self::Cancel(CancelPayload::try_from(value[5..].to_vec())?))
             }
             _ => Err(DecodeError::InvalidMessageType),
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -592,4 +592,92 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_not_interested_normal() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x03];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage = PeerMessage::NotInterested;
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_not_interested_abnormal_bad_id() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_not_interested_abnormal_bad_length() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0xff, 0x03];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_not_interested_abnormal_surplus_data() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x08, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooLong;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_not_interested_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_not_interested_normal() {
+        let message: PeerMessage = PeerMessage::NotInterested;
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x03];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -416,4 +416,92 @@ mod tests {
 
         assert_eq!(actual_bytes, expected_bytes);
     }
+
+    #[test]
+    fn test_decode_unchoke_normal() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x01];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_ok());
+
+        let actual_message: PeerMessage = result.unwrap();
+        let expected_message: PeerMessage = PeerMessage::Unchoke;
+
+        assert_eq!(actual_message, expected_message);
+    }
+
+    #[test]
+    fn test_decode_unchoke_abnormal_bad_id() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0xff];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::InvalidMessageType;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_unchoke_abnormal_bad_length() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0xff, 0x01];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::WrongLength;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_unchoke_abnormal_surplus_data() {
+        let bytes: Bytes = vec![
+            0x00, 0x00, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00,
+        ];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooLong;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_decode_unchoke_abnormal_deficit_data() {
+        let bytes: Bytes = vec![0x00, 0x00, 0x00, 0x00];
+
+        let result: Result<PeerMessage, DecodeError> =
+            PeerMessage::try_from(bytes);
+
+        assert!(result.is_err());
+
+        let actual_error: DecodeError = result.unwrap_err();
+        let expected_error: DecodeError = DecodeError::TooShort;
+
+        assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn test_encode_unchoke_normal() {
+        let message: PeerMessage = PeerMessage::Unchoke;
+
+        let actual_bytes: Bytes = message.into();
+        let expected_bytes: Bytes = vec![0x00, 0x00, 0x00, 0x01, 0x01];
+
+        assert_eq!(actual_bytes, expected_bytes);
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -13,3 +13,9 @@ pub struct RequestPayload {
     begin: usize,
     length: usize,
 }
+
+pub struct PiecePayload {
+    index: usize,
+    begin: usize,
+    piece: Vec<u8>,
+}


### PR DESCRIPTION
# Description #
See #5.

# Acceptance Criteria # 
 - [x] `Choke` messages can be read
 - [x] `Choke` messages can be written
 - [x] `Unchoke` messages can be read
 - [x] `Unchoke` messages can be written
 - [x] `Interested` messages can be read
 - [x] `Interested` messages can be written
 - [x] `Not Interested` messages can be read
 - [x] `Not Interested` messages can be written
 - [x] `Have` messages can be read
 - [x] `Have` messages can be written
 - [x] `Bitfield` messages can be read
 - [x] `Bitfield` messages can be written
 - [x] `Request` messages can be read
 - [x] `Request` messages can be written
 - [x] `Piece` messages can be read
 - [x] `Piece` messages can be written
 - [x] `Cancel` messages can be read
 - [x] `Cancel` messages can be written
